### PR TITLE
feat: Redesign auth modals and add Google SSO buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,31 +31,40 @@
         </section>
 
 
-    <!-- ======================== MODAL DE CONNEXION/INSCRIPTION ======================== -->
-    <div id="authModal" class="modal">
+    <!-- ======================== MODAL DE CONNEXION ======================== -->
+    <div id="loginModal" class="modal">
         <div class="modal-content">
             <span class="close-btn">&times;</span>
-            <div class="form-container">
-                <div class="form-toggle">
-                    <button id="showLoginBtn" class="active">Connexion</button>
-                    <button id="showRegisterBtn">Inscription</button>
-                </div>
+            <form id="loginForm" class="auth-form">
+                <h2>Se connecter</h2>
+                <button type="button" class="google-btn">
+                    <i class="fab fa-google"></i> Se connecter avec Google
+                </button>
+                <div class="separator">ou</div>
+                <input type="email" placeholder="Email" required>
+                <input type="password" placeholder="Mot de passe" required>
+                <button type="submit">Connexion</button>
+                <p class="form-switch">Pas encore de compte ? <a href="#" id="showRegister">Inscrivez-vous</a></p>
+            </form>
+        </div>
+    </div>
 
-                <form id="loginForm" class="auth-form">
-                    <h2>Se connecter</h2>
-                    <input type="email" placeholder="Email" required>
-                    <input type="password" placeholder="Mot de passe" required>
-                    <button type="submit">Connexion</button>
-                </form>
-
-                <form id="registerForm" class="auth-form" style="display: none;">
-                    <h2>Créer un compte</h2>
-                    <input type="text" placeholder="Nom d'utilisateur" required>
-                    <input type="email" placeholder="Email" required>
-                    <input type="password" placeholder="Mot de passe" required>
-                    <button type="submit">S'inscrire</button>
-                </form>
-            </div>
+    <!-- ======================== MODAL D'INSCRIPTION ======================== -->
+    <div id="registerModal" class="modal">
+        <div class="modal-content">
+            <span class="close-btn">&times;</span>
+            <form id="registerForm" class="auth-form">
+                <h2>Créer un compte</h2>
+                <button type="button" class="google-btn">
+                    <i class="fab fa-google"></i> S'inscrire avec Google
+                </button>
+                <div class="separator">ou</div>
+                <input type="text" placeholder="Nom d'utilisateur" required>
+                <input type="email" placeholder="Email" required>
+                <input type="password" placeholder="Mot de passe" required>
+                <button type="submit">S'inscrire</button>
+                <p class="form-switch">Déjà un compte ? <a href="#" id="showLogin">Connectez-vous</a></p>
+            </form>
         </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -70,61 +70,65 @@ document.addEventListener('DOMContentLoaded', () => {
     createSlides();
 
 
-   // ==================== AUTHENTICATION MODAL LOGIC ==================== //
+    // ==================== AUTHENTICATION MODAL LOGIC ==================== //
 
-const modal = document.getElementById('authModal');
-const loginBtn = document.getElementById('loginBtn');
-const signupBtn = document.getElementById('signupBtn');
-const closeBtn = document.querySelector('.close-btn');
+    const loginModal = document.getElementById('loginModal');
+    const registerModal = document.getElementById('registerModal');
 
-const showLoginBtn = document.getElementById('showLoginBtn');
-const showRegisterBtn = document.getElementById('showRegisterBtn');
-const loginForm = document.getElementById('loginForm');
-const registerForm = document.getElementById('registerForm');
+    const loginBtn = document.getElementById('loginBtn');
+    const signupBtn = document.getElementById('signupBtn');
 
-// Function to display the login form
-const displayLoginForm = () => {
-    loginForm.style.display = 'block';
-    registerForm.style.display = 'none';
-    showLoginBtn.classList.add('active');
-    showRegisterBtn.classList.remove('active');
-};
+    const closeLoginBtn = loginModal.querySelector('.close-btn');
+    const closeRegisterBtn = registerModal.querySelector('.close-btn');
 
-// Function to display the registration form
-const displayRegisterForm = () => {
-    loginForm.style.display = 'none';
-    registerForm.style.display = 'block';
-    showRegisterBtn.classList.add('active');
-    showLoginBtn.classList.remove('active');
-};
+    const showRegisterLink = document.getElementById('showRegister');
+    const showLoginLink = document.getElementById('showLogin');
 
-// Opens the modal and displays the login form
-loginBtn.onclick = (e) => {
-    e.preventDefault();
-    modal.style.display = 'block';
-    displayLoginForm();
-}
+    // Function to open a modal
+    function openModal(modal) {
+        modal.style.display = 'block';
+    }
 
-// Opens the modal and displays the registration form
-signupBtn.onclick = (e) => {
-    e.preventDefault();
-    modal.style.display = 'block';
-    displayRegisterForm();
-}
-
-// Handles clicks on the toggle buttons
-showLoginBtn.onclick = displayLoginForm;
-showRegisterBtn.onclick = displayRegisterForm;
-
-// Closes the modal
-closeBtn.onclick = () => {
-    modal.style.display = 'none';
-}
-
-// Closes the modal if the user clicks outside of it
-window.onclick = (event) => {
-    if (event.target == modal) {
+    // Function to close a modal
+    function closeModal(modal) {
         modal.style.display = 'none';
     }
-}
+
+    // Event listeners for navbar buttons
+    loginBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        openModal(loginModal);
+    });
+
+    signupBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        openModal(registerModal);
+    });
+
+    // Event listeners for close buttons
+    closeLoginBtn.addEventListener('click', () => closeModal(loginModal));
+    closeRegisterBtn.addEventListener('click', () => closeModal(registerModal));
+
+    // Event listeners for switching between modals
+    showRegisterLink.addEventListener('click', (e) => {
+        e.preventDefault();
+        closeModal(loginModal);
+        openModal(registerModal);
+    });
+
+    showLoginLink.addEventListener('click', (e) => {
+        e.preventDefault();
+        closeModal(registerModal);
+        openModal(loginModal);
+    });
+
+    // Close modal when clicking outside of it
+    window.addEventListener('click', (e) => {
+        if (e.target === loginModal) {
+            closeModal(loginModal);
+        }
+        if (e.target === registerModal) {
+            closeModal(registerModal);
+        }
+    });
 });

--- a/style.css
+++ b/style.css
@@ -358,37 +358,6 @@ body {
     transform: rotate(90deg); /* Animation de rotation au survol */
 }
 
-/* Le sélecteur de formulaire est plus intégré et stylisé. */
-.form-toggle {
-    display: flex;
-    justify-content: center;
-    margin-bottom: 30px;
-    background-color: #0c0c0c; /* Fond assorti au body */
-    border-radius: 30px;
-    padding: 6px;
-    border: 1px solid var(--border-color);
-}
-
-.form-toggle button {
-    background: transparent;
-    border: none;
-    color: var(--light-text);
-    padding: 12px 20px;
-    cursor: pointer;
-    font-size: 1rem;
-    font-weight: 600;
-    border-radius: 25px;
-    flex: 1;
-    transition: all 0.4s cubic-bezier(0.23, 1, 0.32, 1); /* Transition plus douce */
-}
-
-/* Le bouton actif a un fond dégradé pour correspondre au thème. */
-.form-toggle button.active {
-    background: var(--primary-gradient);
-    color: #fff;
-    box-shadow: 0 4px 15px rgba(249, 115, 22, 0.2);
-}
-
 .auth-form h2 {
     text-align: center;
     margin-bottom: 25px;
@@ -439,4 +408,68 @@ body {
 .auth-form button:hover {
     transform: translateY(-3px);
     box-shadow: 0 8px 25px rgba(249, 115, 22, 0.4);
+}
+
+/* Styles for Google Button */
+.auth-form .google-btn {
+    background: #fff;
+    color: #1a1a1a;
+    margin-bottom: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.3s ease;
+    padding: 14px;
+    font-size: 1rem;
+}
+
+.auth-form .google-btn:hover {
+    background-color: #f0f0f0;
+    transform: translateY(0); /* Override hover effect from generic button */
+    box-shadow: none; /* Override hover effect from generic button */
+}
+
+.auth-form .google-btn i {
+    margin-right: 10px;
+    font-size: 1.2rem;
+    color: #DB4437; /* Google Red */
+}
+
+/* Styles for "or" separator */
+.separator {
+    text-align: center;
+    margin: 20px 0;
+    color: rgba(255, 255, 255, 0.4);
+    text-transform: uppercase;
+    font-size: 0.9rem;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+}
+
+.separator::before,
+.separator::after {
+    content: '';
+    flex-grow: 1;
+    height: 1px;
+    background: var(--border-color);
+    margin: 0 15px;
+}
+
+/* Styles for form switching link */
+.form-switch {
+    text-align: center;
+    margin-top: 25px;
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.form-switch a {
+    color: var(--primary-color);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.form-switch a:hover {
+    text-decoration: underline;
 }


### PR DESCRIPTION
Replaces the single authentication modal with two separate modals for login and registration to provide a clearer user flow.

Adds 'Sign in with Google' and 'Sign up with Google' buttons to the respective modals.

Updates the design to be more modern and consistent with the site's theme.

Rewrites the JavaScript to handle the new two-modal system, including opening, closing, and switching between them.