### PR TITLE
feat: Add redirection to movie page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -271,3 +271,8 @@ body {
     padding: 15px 10px;
     font-weight: 500;
 }
+
+.movie-card-link {
+    text-decoration: none;
+    color: inherit;
+}

--- a/js/script.js
+++ b/js/script.js
@@ -10,18 +10,21 @@ document.addEventListener('DOMContentLoaded', () => {
     //movies that figure here are the same as the ones in the trending section
     const movies = [
         {
+            id: 1,
             title: 'Dune: Part Two',
             description: 'Paul Atreides unites with Chani and the Fremen to lead a rebellion against those who destroyed his family.',
             image: 'https://image.tmdb.org/t/p/original/8b8R8l88Qje9dn9OE8PY05Nxl1X.jpg',
             category: 'Action/Sci-Fi'
         },
         {
+            id: 2,
             title: 'Godzilla x Kong: The New Empire',
             description: 'The all-powerful Kong and the fearsome Godzilla unite their forces against a terrible threat.',
             image: 'https://image.tmdb.org/t/p/original/v5XyXZe8FADw8iHupB4L7QOAwH9.jpg',
             category: 'Action/Adventure'
         },
         {
+            id: 3,
             title: 'Kung Fu Panda 4',
             description: 'Po must find and train a new Dragon Warrior, but a wicked sorceress plans to re-summon all the villainous masters that Po has defeated.',
             image: 'https://image.tmdb.org/t/p/original/kDp1vUBnMpe8ak4rjgl3cLELqjU.jpg',
@@ -41,7 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         <span class="genre-tag">${movie.category}</span>
                         <h1>${movie.title}</h1>
                         <p>${movie.description}</p>
-                        <a href="#" class="watch-btn"><i class="fas fa-play"></i> watch now</a> 
+                        <a href="movie.html?id=${movie.id}" class="watch-btn"><i class="fas fa-play"></i> watch now</a>
                     </div>
                 </div>
             `;
@@ -78,10 +81,12 @@ document.addEventListener('DOMContentLoaded', () => {
     function createMovieCards() {
         movies.forEach(movie => {
             const movieCard = `
-                <div class="movie-card">
-                    <img src="${movie.image}" alt="${movie.title}">
-                    <h3>${movie.title}</h3>
-                </div>
+                <a href="movie.html?id=${movie.id}" class="movie-card-link">
+                    <div class="movie-card">
+                        <img src="${movie.image}" alt="${movie.title}">
+                        <h3>${movie.title}</h3>
+                    </div>
+                </a>
             `;
             moviesGrid.innerHTML += movieCard;
         });


### PR DESCRIPTION
This commit implements the redirection to a movie-specific page when a user clicks on a "Watch Now" button or a movie card.

- Adds unique IDs to the movie data objects.
- Updates the "Watch Now" button in the hero carousel to link to `movie.html?id=<movie_id>`.
- Wraps the movie cards in the trending section with an `<a>` tag pointing to `movie.html?id=<movie_id>`.
- Adds CSS to disable default link styling on the movie cards to preserve the UI.